### PR TITLE
Add explicit coast-mode commands for VESC-driven back motors 

### DIFF
--- a/include/VescController.h
+++ b/include/VescController.h
@@ -15,6 +15,7 @@ class VescController {
 
     void SetMode(Mode mode);
     void SetCmd(float cmd);
+    void SetCoast();
     void SetScale(float scale) { _scale = scale; }
 
     double GetVoltage() { return _voltageIn; }

--- a/include/subsystems/DriveBase.h
+++ b/include/subsystems/DriveBase.h
@@ -27,6 +27,7 @@ class DriveBase : public SubsystemBase {
     void ReportState(std::string prefix = "/") override;
     DriveBaseFeedback GetVelocities();
     inline void SetCmds(DriveBaseCmds cmds) { _cmds = cmds; }
+    void SetCoastMode(bool coast);
 
     // void SetObstacleDetected(bool obstacleDetected) {
     //     _obstacleDetected = obstacleDetected;
@@ -41,6 +42,7 @@ class DriveBase : public SubsystemBase {
     VescController _right_front;
     VescController _left_back;
     VescController _right_back;
-
+ 
     double _voltage;
+    bool _coast{false};
 };

--- a/src/Robot.cpp
+++ b/src/Robot.cpp
@@ -104,7 +104,9 @@ void Robot::Run(int rate, bool &running) {
         }
         cmds = _overrideController.Run(cmds);
 
-        if (_enabled) {
+        const bool coastMode = !_enabled.load() || _mode.load() == ControlMode::DISABLED;
+        _driveBase.SetCoastMode(coastMode);
+        if (!coastMode && _enabled) {
             // Commmand subsystems
             _driveBase.SetCmds(cmds.drive);
         }
@@ -154,7 +156,10 @@ void Robot::HandleNetCmd(const std::string &cmd, rapidjson::Document &doc) {
     }
 }
 
-void Robot::Shutdown() { _vision.Disconnect(); }
+void Robot::Shutdown() {
+    _driveBase.SetCoastMode(true);
+    _vision.Disconnect();
+}
 
 void Robot::ManageController() {
     if (_newMode != _mode) {

--- a/src/VescController.cpp
+++ b/src/VescController.cpp
@@ -52,6 +52,11 @@ void VescController::SetCmd(float cmd) {
     }
 }
 
+void VescController::SetCoast() {
+    _cmdDutyCycle = 0.0;
+    sendDutyCycle(0.0f);
+}
+
 static void print_buf(const char* title, const unsigned char* buf,
                       size_t buf_len) {
     size_t i = 0;

--- a/src/subsystems/DriveBase.cpp
+++ b/src/subsystems/DriveBase.cpp
@@ -27,7 +27,28 @@ DriveBase::DriveBase()
     _right_back.SetMode(mode);
 }
 
+void DriveBase::SetCoastMode(bool coast) {
+    _coast = coast;
+    if (!_coast) {
+        return;
+    }
+
+    _left_front.SetCoast();
+    _right_front.SetCoast();
+    _left_back.SetCoast();
+    _right_back.SetCoast();
+}
+
 void DriveBase::Update(double dt) {
+    if (_coast) {
+        _left_front.SetCoast();
+        _right_front.SetCoast();
+        _left_back.SetCoast();
+        _right_back.SetCoast();
+        _cmds = {0, 0};
+        return;
+    }
+
     // Utils::LogFmt("Drivebase Speeds: lb %f  lf %f  rb %f  sb %f",
     // _cmds._lb_speed, _cmds._lf_speed, _cmds._rb_speed, _cmds._rf_speed);
 


### PR DESCRIPTION
This branch adds explicit coast-mode handling for the VESC-driven back motors.

Changes:
- include/VescController.h, src/VescController.cpp: added SetCoast() to send a zero-duty CAN command to VESC controllers.
- include/subsystems/DriveBase.h, src/subsystems/DriveBase.cpp: added coast-mode behavior so motors are commanded to coast when the robot is disabled or shutting down.
- src/Robot.cpp: enables drive-base coast mode during disabled states and on shutdown.

Notes:
- The controllers are VESC6 MK5 units; the code changes target those controllers' zero-duty/coast behavior.
- Build/test not run in this PR per user instruction to ignore additional dependency installation. Recommend running the WSL build locally or in CI to verify.
